### PR TITLE
remove fixed height

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -90,7 +90,7 @@ h2 {
 
 .container {
   margin: auto;
-  margin-top: -50px;
+  // margin-top: -50px;
   min-width: 900px;
   box-sizing: content-box;
   padding: 20px;
@@ -99,8 +99,8 @@ h2 {
   max-width: 90vw;
   width: 1200px;
   justify-content: center;
-  align-items: center;
-  height:100%;
+  // align-items: center;
+  // height:100%;
 }
 
 .left {


### PR DESCRIPTION
This is an emergency hot fix so I'm merging it myself. It removes the fixed height, which was preventing elements from showing up in some cases. 

I am by no means a flexbox expert and there is probably a much more graceful way to do this, so perhaps @Cinders-P or @Daynil could take a look when time permits.